### PR TITLE
Relationship start date reached trigger added

### DIFF
--- a/CRM/Civirules/Upgrader.php
+++ b/CRM/Civirules/Upgrader.php
@@ -744,5 +744,13 @@ class CRM_Civirules_Upgrader extends CRM_Civirules_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_2051() {
+    CRM_Core_DAO::executeQuery("
+        INSERT INTO civirule_trigger (name, label, object_name, op, cron, class_name, created_date, created_user_id)
+        VALUES
+        ('relationship_activated', 'Relationship start date reached', 'Relationship', 'edit', 1, 'CRM_CivirulesCronTrigger_RelationshipStartDate',  CURDATE(), 1);
+    ");
+    return TRUE;
+  }
 }
 

--- a/CRM/CivirulesCronTrigger/RelationshipStartDate.php
+++ b/CRM/CivirulesCronTrigger/RelationshipStartDate.php
@@ -1,0 +1,56 @@
+<?php
+
+class CRM_CivirulesCronTrigger_RelationshipStartDate extends CRM_Civirules_Trigger_Cron {
+
+  private $dao = false;
+
+  /**
+   * Returns an array of entities on which the trigger reacts
+   *
+   * @return CRM_Civirules_TriggerData_EntityDefinition
+   */
+  protected function reactOnEntity() {
+    return new CRM_Civirules_TriggerData_EntityDefinition('Relationship', 'Relationship', 'CRM_Contact_DAO_Relationship', 'Relationship');
+  }
+
+  /**
+   * This method returns a CRM_Civirules_TriggerData_TriggerData this entity is used for triggering the rule
+   *
+   * Return false when no next entity is available
+   *
+   * @return object|bool CRM_Civirules_TriggerData_TriggerData|false
+   * @access protected
+   */
+  protected function getNextEntityTriggerData() {
+    if (!$this->dao) {
+      $this->queryForTriggerEntities();
+    }
+    if ($this->dao->fetch()) {
+      $data = array();
+      CRM_Core_DAO::storeValues($this->dao, $data);
+      $triggerData = new CRM_Civirules_TriggerData_Cron($this->dao->contact_id_a, 'Relationship', $data);
+      return $triggerData;
+    }
+    return false;
+  }
+
+  /**
+   * Method to query trigger entities
+   *
+   * @access private
+   */
+  private function queryForTriggerEntities() {
+    $sql = "SELECT r.*
+            FROM `civicrm_relationship` `r`
+            WHERE `r`.`is_active` = 1
+            AND `r`.`start_date` IS NOT NULL
+            AND `r`.`start_date` = CURDATE()
+            AND `r`.`contact_id_a` NOT IN (
+              SELECT `rule_log`.`contact_id`
+              FROM `civirule_rule_log` `rule_log`
+              WHERE `rule_log`.`rule_id` = %1 AND DATE(`rule_log`.`log_date`) = DATE(NOW())
+            );";
+    $params[1] = array($this->ruleId, 'Integer');
+    $this->dao = CRM_Core_DAO::executeQuery($sql, $params, true, 'CRM_Contact_BAO_Relationship');
+  }
+}

--- a/sql/triggers.json
+++ b/sql/triggers.json
@@ -100,4 +100,6 @@
   {"name": "changed_campaign", "label": "Campaign is changed", "object_name": "Campaign", "op": "edit", "class_name": null, "cron": "0"},
   {"name": "deleted_campaign", "label": "Campaign is deleted", "object_name": "Campaign", "op": "delete", "class_name": null, "cron": "0"},
   {"name": "created_actionlog", "label": "Scheduled Reminder log is added", "object_name": "ActionLog", "op": "create", "class_name":"CRM_CivirulesPostTrigger_ActionLog", "cron": "0"},
-  {"name": "changed_actionlog", "label": "Scheduled Reminder log is changed", "object_name": "ActionLog", "op": "edit", "class_name":"CRM_CivirulesPostTrigger_ActionLog", "cron": "0"}]
+  {"name": "changed_actionlog", "label": "Scheduled Reminder log is changed", "object_name": "ActionLog", "op": "edit", "class_name":"CRM_CivirulesPostTrigger_ActionLog", "cron": "0"},
+  {"name": "relationship_activated", "label": "Relationship start date reached", "object_name": "Relationship", "op": "edit", "class_name": "CRM_CivirulesCronTrigger_RelationshipStartDate", "cron": "1"}
+]


### PR DESCRIPTION
## Overview
This pr changes adds a new trigger that would check if there any relationships that are being activated today.

## Technical Details
- This pr adds a new trigger as ```CRM/CivirulesCronTrigger/RelationshipStartDate.php``` it queries the ```civicrm_relationship``` table and checks if there are any relationships that have start date equals to current date.
- This pr also adds upgrader  fucntion to add this new trigger to database.