### PR TITLE
Relationship End Date Trigger And Remove Contact Subtype Action Added

### DIFF
--- a/CRM/CivirulesActions/Contact/Form/RemoveSubtype.php
+++ b/CRM/CivirulesActions/Contact/Form/RemoveSubtype.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Class for CiviRules Group Contact Action Form
+ *
+ * @author Jaap Jansma (CiviCooP) <jaap.jansma@civicoop.org>
+ * @license AGPL-3.0
+ */
+
+class CRM_CivirulesActions_Contact_Form_RemoveSubtype extends CRM_CivirulesActions_Form_Form {
+
+  /**
+   * Method to get groups
+   *
+   * @return array
+   * @access protected
+   */
+  protected function getSubtypes() {
+    $types = CRM_Contact_BAO_ContactType::contactTypeInfo();
+    $options = array();
+    foreach($types as $name => $type) {
+      if(!empty($type['parent_id'])) {
+        $options[$name] = $type['parent_label'].' - '.$type['label'];
+      }
+    }
+    return $options;
+  }
+
+  /**
+   * Overridden parent method to build the form
+   *
+   * @access public
+   */
+  public function buildQuickForm() {
+    $this->add('hidden', 'rule_action_id');
+
+    $this->add('select', 'type', ts('Single/Multiple'), array(
+      0 => ts('Remove one subtype'),
+      1 => ts('Remove multiple subtypes'),
+    ));
+
+    $this->add('select', 'subtype', ts('Contact sub type'), array('' => ts('-- please select --')) + $this->getSubtypes());
+
+    $multiGroup = $this->addElement('advmultiselect', 'subtypes', ts('Contact sub types'), $this->getSubtypes(), array(
+      'size' => 5,
+      'style' => 'width:250px',
+      'class' => 'advmultiselect',
+    ));
+
+    $multiGroup->setButtonAttributes('add', array('value' => ts('Add >>')));
+    $multiGroup->setButtonAttributes('remove', array('value' => ts('<< Remove')));
+
+    $this->addButtons(array(
+      array('type' => 'next', 'name' => ts('Save'), 'isDefault' => TRUE,),
+      array('type' => 'cancel', 'name' => ts('Cancel'))));
+  }
+
+  public function addRules() {
+    $this->addFormRule(array('CRM_CivirulesActions_Contact_Form_RemoveSubtype', 'validateSubtype'));
+  }
+
+  /**
+   * Function to validate value of rule action form
+   *
+   * @param array $fields
+   * @return array|bool
+   * @access public
+   * @static
+   */
+  static function validateSubtype($fields) {
+    $errors = array();
+    if ($fields['type'] == 0 && empty($fields['subtype'])) {
+      $errors['subtype'] = ts('You have to select at least one subtype');
+    } elseif ($fields['type'] == 1 && (empty($fields['subtypes']) || count($fields['subtypes']) < 1)) {
+      $errors['subtypes'] = ts('You have to select at least one subtype');
+    }
+
+    if (count($errors)) {
+      return $errors;
+    }
+    return true;
+  }
+
+  /**
+   * Overridden parent method to set default values
+   *
+   * @return array $defaultValues
+   * @access public
+   */
+  public function setDefaultValues() {
+    $defaultValues = parent::setDefaultValues();
+    $data = unserialize($this->ruleAction->action_params);
+    if (!empty($data['sub_type'])) {
+      $defaultValues['sub_type'] = reset($data['sub_type']);
+      $defaultValues['sub_types'] = $data['sub_type'];
+    }
+    if (!empty($data['sub_type']) && count($data['sub_type']) <= 1) {
+      $defaultValues['type'] = 0;
+    } elseif (!empty($data['sub_type'])) {
+      $defaultValues['type'] = 1;
+    }
+    return $defaultValues;
+  }
+
+  /**
+   * Overridden parent method to process form data after submitting
+   *
+   * @access public
+   */
+  public function postProcess() {
+    $data['sub_type'] = array();
+    if ($this->_submitValues['type'] == 0) {
+      $data['sub_type'] = array($this->_submitValues['subtype']);
+    } else {
+      $data['sub_type'] = $this->_submitValues['subtypes'];
+    }
+
+    $this->ruleAction->action_params = serialize($data);
+    $this->ruleAction->save();
+    parent::postProcess();
+  }
+
+}

--- a/CRM/CivirulesActions/Contact/RemoveSubtype.php
+++ b/CRM/CivirulesActions/Contact/RemoveSubtype.php
@@ -1,0 +1,65 @@
+<?php
+
+class CRM_CivirulesActions_Contact_RemoveSubtype extends CRM_Civirules_Action {
+
+  /**
+   * Method processAction to execute the action
+   *
+   * @param CRM_Civirules_TriggerData_TriggerData $triggerData
+   * @access public
+   */
+  public function processAction(CRM_Civirules_TriggerData_TriggerData $triggerData) {
+    $contactId = $triggerData->getContactId();
+
+    $subTypes = CRM_Contact_BAO_Contact::getContactSubType($contactId);
+    $contactType = CRM_Contact_BAO_Contact::getContactType($contactId);
+    $typesToRemove = [];
+    $changed = false;
+    $actionParams = $this->getActionParameters();
+    foreach($actionParams['sub_type'] as $subType) {
+      if (in_array($subType, $subTypes )) {
+        $typesToRemove[] = $subType;
+        $changed = true;
+      }
+    }
+    if ($changed) {
+      $params['id'] = $contactId;
+      $params['contact_id'] = $contactId;
+      $params['contact_type'] = $contactType;
+      $params['contact_sub_type'] = array_diff($subTypes, $typesToRemove);
+      CRM_Contact_BAO_Contact::add($params);
+    }
+  }
+
+  /**
+   * Method to return the url for additional form processing for action
+   * and return false if none is needed
+   *
+   * @param int $ruleActionId
+   * @return bool
+   * @access public
+   */
+  public function getExtraDataInputUrl($ruleActionId) {
+    return CRM_Utils_System::url('civicrm/civirule/form/action/contact/subtype/remove', 'rule_action_id='.$ruleActionId);
+  }
+
+  /**
+   * Returns a user friendly text explaining the condition params
+   * e.g. 'Older than 65'
+   *
+   * @return string
+   * @access public
+   */
+  public function userFriendlyConditionParams() {
+    $params = $this->getActionParameters();
+    $label = ts('Remove contact subtype');
+    $subTypeLabels = array();
+    $subTypes = CRM_Contact_BAO_ContactType::contactTypeInfo();
+    foreach($params['sub_type'] as $subType) {
+      $subTypeLabels[] = $subTypes[$subType]['parent_label'].' - '.$subTypes[$subType]['label'];
+    }
+    $label .= implode(', ', $subTypeLabels);
+    return $label;
+  }
+
+}

--- a/CRM/CivirulesCronTrigger/RelationshipEnd.php
+++ b/CRM/CivirulesCronTrigger/RelationshipEnd.php
@@ -1,0 +1,55 @@
+<?php
+
+class CRM_CivirulesCronTrigger_RelationshipEnd extends CRM_Civirules_Trigger_Cron {
+
+  private $dao = false;
+
+  /**
+   * Returns an array of entities on which the triggerreacts
+   *
+   * @return CRM_Civirules_TriggerData_EntityDefinition
+   */
+  protected function reactOnEntity() {
+    return new CRM_Civirules_TriggerData_EntityDefinition('Relationship', 'Relationship', 'CRM_Contact_DAO_Relationship', 'Relationship');
+  }
+
+  /**
+   * This method returns a CRM_Civirules_TriggerData_TriggerData this entity is used for triggering the rule
+   *
+   * Return false when no next entity is available
+   *
+   * @return object|bool CRM_Civirules_TriggerData_TriggerData|false
+   * @access protected
+   */
+  protected function getNextEntityTriggerData() {
+    if (!$this->dao) {
+      $this->queryForTriggerEntities();
+    }
+    if ($this->dao->fetch()) {
+      $data = array();
+      CRM_Core_DAO::storeValues($this->dao, $data);
+      $triggerData = new CRM_Civirules_TriggerData_Cron($this->dao->contact_id_a, 'Relationship', $data);
+      return $triggerData;
+    }
+    return false;
+  }
+
+  /**
+   * Method to query trigger entities
+   *
+   * @access private
+   */
+  private function queryForTriggerEntities() {
+    $sql = "SELECT r.*
+            FROM `civicrm_relationship` `r`
+            WHERE `r`.`end_date` IS NOT NULL
+            AND `r`.`end_date` <= CURDATE()
+            AND `r`.`contact_id_a` NOT IN (
+              SELECT `rule_log`.`contact_id`
+              FROM `civirule_rule_log` `rule_log`
+              WHERE `rule_log`.`rule_id` = %1 AND DATE(`rule_log`.`log_date`) = DATE(NOW())
+            );";
+    $params[1] = array($this->ruleId, 'Integer');
+    $this->dao = CRM_Core_DAO::executeQuery($sql, $params, true, 'CRM_Contact_BAO_Relationship');
+  }
+}

--- a/sql/actions.json
+++ b/sql/actions.json
@@ -24,5 +24,6 @@
   {"name":"participant_update_status","label":"Update Participant Status","class_name":"CRM_CivirulesActions_Participant_UpdateStatus"},
   {"name":"Relationship_add", "label":"Add relationship", "class_name":"CRM_CivirulesActions_Relationship_Add"},
   {"name":"membership_add","label":"Add Membership","class_name":"CRM_CivirulesActions_Membership_Add"},
-  {"name":"contribution_financial_type","label":"Set the Financial Type for a Contribution","class_name":"CRM_CivirulesActions_Contribution_FinancialType"}
+  {"name":"contribution_financial_type","label":"Set the Financial Type for a Contribution","class_name":"CRM_CivirulesActions_Contribution_FinancialType"},
+  {"name":"remove_contact_sub_type","label":"Remove one or more sub contact types","class_name":"CRM_CivirulesActions_Contact_RemoveSubtype"}
 ]

--- a/sql/triggers.json
+++ b/sql/triggers.json
@@ -101,5 +101,6 @@
   {"name": "deleted_campaign", "label": "Campaign is deleted", "object_name": "Campaign", "op": "delete", "class_name": null, "cron": "0"},
   {"name": "created_actionlog", "label": "Scheduled Reminder log is added", "object_name": "ActionLog", "op": "create", "class_name":"CRM_CivirulesPostTrigger_ActionLog", "cron": "0"},
   {"name": "changed_actionlog", "label": "Scheduled Reminder log is changed", "object_name": "ActionLog", "op": "edit", "class_name":"CRM_CivirulesPostTrigger_ActionLog", "cron": "0"},
-  {"name": "relationship_activated", "label": "Relationship start date reached", "object_name": "Relationship", "op": "edit", "class_name": "CRM_CivirulesCronTrigger_RelationshipStartDate", "cron": "1"}
+  {"name": "relationship_activated", "label": "Relationship start date reached", "object_name": "Relationship", "op": "edit", "class_name": "CRM_CivirulesCronTrigger_RelationshipStartDate", "cron": "1"},
+  {"name": "relationship_end", "label": "Relationship end date reached", "object_name": "Relationship", "op": "edit", "class_name": "CRM_CivirulesCronTrigger_RelationshipEnd", "cron": "1"}
 ]

--- a/templates/CRM/CivirulesActions/Contact/Form/RemoveSubtype.tpl
+++ b/templates/CRM/CivirulesActions/Contact/Form/RemoveSubtype.tpl
@@ -1,0 +1,43 @@
+<h3>{$ruleActionHeader}</h3>
+<div class="crm-block crm-form-block crm-civirule-rule_action-block-contact_subtype">
+  <div class="crm-section">
+    <div class="label">{$form.type.label}</div>
+    <div class="content">{$form.type.html}</div>
+    <div class="clear"></div>
+  </div>
+  <div class="crm-section sub_type-single">
+    <div class="label">{$form.subtype.label}</div>
+    <div class="content">{$form.subtype.html}</div>
+    <div class="clear"></div>
+  </div>
+  <div class="crm-section sub_type-multiple" style="display: none;">
+    <div class="label">{$form.subtypes.label}</div>
+    <div class="content">{$form.subtypes.html}</div>
+    <div class="clear"></div>
+  </div>
+</div>
+<div class="crm-submit-buttons">
+  {include file="CRM/common/formButtons.tpl" location="bottom"}
+</div>
+
+{literal}
+  <script type="text/javascript">
+    cj(function() {
+      cj('select#type').change(triggerTypeChange);
+
+      triggerTypeChange();
+    });
+
+    function triggerTypeChange() {
+      cj('.sub_type-multiple').css('display', 'none');
+      cj('.sub_type-single').css('display', 'none');
+      var val = cj('#type').val();
+      if (val == 0 ) {
+        cj('.sub_type-single').css('display', 'block');
+      } else {
+        cj('.sub_type-multiple').css('display', 'block');
+      }
+    }
+  </script>
+
+{/literal}

--- a/xml/Menu/civirules.xml
+++ b/xml/Menu/civirules.xml
@@ -549,4 +549,11 @@
     <access_arguments>access CiviCRM</access_arguments>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/civirule/form/action/contact/subtype/remove</path>
+    <page_callback>CRM_CivirulesActions_Contact_Form_RemoveSubtype</page_callback>
+    <title>Remove Contact Subtype</title>
+    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
## Overview
This pr changes adds a new trigger that would check if there are any relationships that are being deactivated today or earlier then today. It also create a new action which will allow users to remove sub contact types for a contact.

## Technical Details
- This pr adds a new trigger as ```CRM/CivirulesCronTrigger/RelationshipEndDate.php``` it queries the ```civicrm_relationship``` table and checks if there are any relationships that have end date equals to or smaller than current date.
- This pr also adds an action ```CRM_CivirulesActions_Contact_RemoveSubtype``` which will remove one or more sub types for a contact.